### PR TITLE
feat(deps): Update bouncycastle from 1.64 to 1.72

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <deps.commons-net.version>3.9.0</deps.commons-net.version>
         <deps.commons-validator.version>1.7</deps.commons-validator.version>
         <deps.guava.version>31.1-jre</deps.guava.version>
-        <deps.bouncycastle.version>1.64</deps.bouncycastle.version>
+        <deps.bouncycastle.version>1.72</deps.bouncycastle.version>
         <deps.jcommander.version>1.82</deps.jcommander.version>
         <deps.json-simple.version>1.1.1</deps.json-simple.version>
         <deps.jackson.version>2.14.1</deps.jackson.version>
@@ -503,12 +503,12 @@
             <!-- Bouncy Castle -->
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
+                <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${deps.bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
+                <artifactId>bcprov-jdk18on</artifactId>
                 <version>${deps.bouncycastle.version}</version>
             </dependency>
             <!-- Persistence -->


### PR DESCRIPTION
The bouncycastle version that is currently used is very old (> 3 years) and also known to be vulnerable ([CVE-2020-15522][1]). The newer bouncycastle versions also feature some useful additions, e.g. for [parsing SSH2 RSA keys][2]. Hence, it makes sense to update to the latest version.

The bouncycastle variant `jdk15on` that is currently used by the projects under the TLS-Attacker umbrella is not updated anymore and we need to switch to `jdk18on`. This should be no problem because all projects should already support Java 8. Unfortunately, the `artifactId` change requires touching the POM files for each individual project though.

[1]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15522
[2]: https://github.com/bcgit/bc-java/commit/563773c207ab885bb747b791026bf030b3d6d85d